### PR TITLE
Add an optionnal ConfigureWebHostBuilder method call

### DIFF
--- a/src/GeekLearning.DotNet.Swashbuckle/CommandLineOptions.cs
+++ b/src/GeekLearning.DotNet.Swashbuckle/CommandLineOptions.cs
@@ -90,7 +90,7 @@
                 options.OutputPath = output.Value() ?? "swagger.json";
                 options.ApiVersion = apiVersion.Value() ?? "v1";
                 options.RemainingArguments = app.RemainingArguments;
-                options.AspnetcoreEnvironment = aspnetcoreEnvironment.Value(); 
+                options.AspnetcoreEnvironment = aspnetcoreEnvironment.Value();
                 return 0;
             });
         }

--- a/src/GeekLearning.DotNet.Swashbuckle/Program.cs
+++ b/src/GeekLearning.DotNet.Swashbuckle/Program.cs
@@ -30,27 +30,6 @@
             var projectDirectory = Path.GetDirectoryName(projectFile);
             var (properties, references) = ReadProperties(projectFile, options.Configuration, options.Framework?.Framework);
 
-            var hasNetCoreAppFramework = false;
-            if (properties.TryGetValue(targetFrameworkProperty, out var framework)
-                && !string.IsNullOrEmpty(framework)
-                && framework.StartsWith(netCoreAppFramework))
-            {
-                hasNetCoreAppFramework = true;
-            }
-
-            if (properties.TryGetValue(targetFrameworksProperty, out var tfms)
-                && !string.IsNullOrEmpty(tfms))
-            {
-                foreach (var tfm in tfms.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
-                {
-                    if (tfm.StartsWith(netCoreAppFramework))
-                    {
-                        hasNetCoreAppFramework = true;
-                        break;
-                    }
-                }
-            }
-
             var tempProjectPath = Path.Combine(projectDirectory, properties[intermediateOutputPathProperty], "SwaggerGen");
             if (!Directory.Exists(tempProjectPath))
             {
@@ -62,13 +41,12 @@
             var generationContext = new
             {
                 ProjectPath = projectFile,
-                //IsNetCoreApp = hasNetCoreAppFramework && (options.Framework == null || options.Framework.Framework.StartsWith(netCoreAppFramework)),
                 TargetFramework = properties[targetFrameworkProperty],
                 AssemblyName = properties[assemblyNameProperty],
                 ContentRoot = projectDirectory,
-                ApiVersion = options.ApiVersion,
+                options.ApiVersion,
                 OutputPath = Path.IsPathRooted(options.OutputPath) ? options.OutputPath : Path.Combine(projectDirectory, options.OutputPath),
-                References = references.ToDictionary(x=> x.Key.Replace(".", ""), y=> y.Value)
+                References = references.ToDictionary(x => x.Key.Replace(".", ""), y => y.Value)
             };
 
             var assembly = typeof(Program).GetTypeInfo().Assembly;
@@ -79,11 +57,11 @@
                     var template = Handlebars.Compile(reader.ReadToEnd());
                     File.WriteAllText(
                         Path.Combine(
-                            tempProjectPath, 
+                            tempProjectPath,
                             Path.GetFileNameWithoutExtension(
                                 filePath
                                     .Replace("GeekLearning.DotNet.Swashbuckle.ProjectTemplate.", "")
-                                    .Replace(".cst", ".cs"))), 
+                                    .Replace(".cst", ".cs"))),
                         template(generationContext));
                 }
             }
@@ -99,6 +77,7 @@
                 {
                     run.EnvironmentVariable("ASPNETCORE_ENVIRONMENT", options.AspnetcoreEnvironment);
                 }
+
                 run.WorkingDirectory(tempProjectPath);
                 result = run.Execute();
             }
@@ -114,7 +93,6 @@
             }
 
             var projectPath = project ?? searchBase;
-
             if (!Path.IsPathRooted(projectPath))
             {
                 projectPath = Path.Combine(searchBase, projectPath);
@@ -147,7 +125,7 @@
             return projectPath;
         }
 
-        private static (Dictionary<string, string> Properties, Dictionary<string, string> References)  ReadProperties(string projectFile, string configuration, string framework)
+        private static (Dictionary<string, string> Properties, Dictionary<string, string> References) ReadProperties(string projectFile, string configuration, string framework)
         {
             var targetFileName = Path.GetFileName(projectFile) + ".dotnet-names.targets";
             var projectExtPath = Path.Combine(Path.GetDirectoryName(projectFile), "obj");
@@ -173,12 +151,13 @@ $@"<Project>
                 additionnalParameters = $"/p:{targetFrameworkProperty}={framework}";
             }
 
-            var tmpFile = Path.GetTempFileName();
-            var tmpFile2 = Path.GetTempFileName();
+            var dotNetNamesFileName = Path.GetTempFileName();
+            var dotNetReferencesFileName = Path.GetTempFileName();
+
             var psi = new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"msbuild \"{projectFile}\" /p:Configuration={configuration} /t:_GetDotNetNames /nologo \"/p:_DotNetNamesFile={tmpFile}\" \"/p:_DotNetReferencesFile={tmpFile2}\" {additionnalParameters}"
+                Arguments = $"msbuild \"{projectFile}\" /p:Configuration={configuration} /t:_GetDotNetNames /nologo \"/p:_DotNetNamesFile={dotNetNamesFileName}\" \"/p:_DotNetReferencesFile={dotNetReferencesFileName}\" {additionnalParameters}"
             };
 
             var process = Process.Start(psi);
@@ -188,22 +167,24 @@ $@"<Project>
                 throw new Exception("Invoking MSBuild target failed");
             }
 
-            var lines = File.ReadAllLines(tmpFile);
-            File.Delete(tmpFile);
+            var lines = File.ReadAllLines(dotNetNamesFileName);
+            File.Delete(dotNetNamesFileName);
 
             var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var line in lines)
             {
-                var idx = line.IndexOf(':');
-                if (idx <= 0) continue;
-                var name = line.Substring(0, idx)?.Trim();
-                var value = line.Substring(idx + 1)?.Trim();
+                var index = line.IndexOf(':');
+                if (index <= 0)
+                {
+                    continue;
+                }
+
+                var name = line.Substring(0, index)?.Trim();
+                var value = line.Substring(index + 1)?.Trim();
                 properties.Add(name, value);
             }
 
-
-            var referencesLines = File.ReadAllLines(tmpFile2);
-
+            var referencesLines = File.ReadAllLines(dotNetReferencesFileName);
             var references = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var line in referencesLines)

--- a/src/GeekLearning.DotNet.Swashbuckle/Program.cs
+++ b/src/GeekLearning.DotNet.Swashbuckle/Program.cs
@@ -131,19 +131,20 @@
             var projectExtPath = Path.Combine(Path.GetDirectoryName(projectFile), "obj");
             var targetFile = Path.Combine(projectExtPath, targetFileName);
 
-            File.WriteAllText(targetFile,
-$@"<Project>
-      <Target Name=""_GetDotNetNames"" DependsOnTargets=""ResolvePackageDependenciesDesignTime"">
-         <ItemGroup>
-            <_DotNetNamesOutput Include=""{assemblyNameProperty}: $({assemblyNameProperty})"" />
-            <_DotNetNamesOutput Include=""{targetFrameworkProperty}: $({targetFrameworkProperty})"" />
-            <_DotNetNamesOutput Include=""{targetFrameworksProperty}: $({targetFrameworksProperty})"" />
-            <_DotNetNamesOutput Include=""{intermediateOutputPathProperty}: $({intermediateOutputPathProperty})"" />
-         </ItemGroup>
-         <WriteLinesToFile File=""$(_DotNetNamesFile)"" Lines=""@(_DotNetNamesOutput)"" Overwrite=""true"" />
-         <WriteLinesToFile File=""$(_DotNetReferencesFile)"" Lines=""@(_DependenciesDesignTime)"" Overwrite=""true"" />
-      </Target>
-  </Project>");
+            File.WriteAllText(
+                targetFile,
+                $@"<Project>
+                      <Target Name=""_GetDotNetNames"" DependsOnTargets=""ResolvePackageDependenciesDesignTime"">
+                         <ItemGroup>
+                            <_DotNetNamesOutput Include=""{assemblyNameProperty}: $({assemblyNameProperty})"" />
+                            <_DotNetNamesOutput Include=""{targetFrameworkProperty}: $({targetFrameworkProperty})"" />
+                            <_DotNetNamesOutput Include=""{targetFrameworksProperty}: $({targetFrameworksProperty})"" />
+                            <_DotNetNamesOutput Include=""{intermediateOutputPathProperty}: $({intermediateOutputPathProperty})"" />
+                         </ItemGroup>
+                         <WriteLinesToFile File=""$(_DotNetNamesFile)"" Lines=""@(_DotNetNamesOutput)"" Overwrite=""true"" />
+                         <WriteLinesToFile File=""$(_DotNetReferencesFile)"" Lines=""@(_DependenciesDesignTime)"" Overwrite=""true"" />
+                      </Target>
+                  </Project>");
 
             var additionnalParameters = string.Empty;
             if (!string.IsNullOrEmpty(framework))

--- a/src/GeekLearning.DotNet.Swashbuckle/ProjectTemplate/Program.cst.hbs
+++ b/src/GeekLearning.DotNet.Swashbuckle/ProjectTemplate/Program.cst.hbs
@@ -37,9 +37,18 @@
                 return (int)ExitCodes.StartupClassNotFound;
             }
 
-            var testServer = new TestServer(new WebHostBuilder()
+            var webHostBuilder = new WebHostBuilder()
                 .UseContentRoot(contentRoot)
-                .UseStartup(startup));
+                .UseStartup(startup);
+
+            var entryPointType = assembly.EntryPoint.DeclaringType;
+            var webHostBuilderConfigurator = entryPointType.GetMethod("ConfigureWebHostBuilder");
+            if (webHostBuilderConfigurator != null)
+            {
+                webHostBuilder = (IWebHostBuilder)webHostBuilderConfigurator.Invoke(null, new object[] { webHostBuilder });
+            }
+
+            var testServer = new TestServer(webHostBuilder);
 
             var scopeFactory = testServer.Host.Services.GetRequiredService<IServiceScopeFactory>();
             var mvcJsonOptions = testServer.Host.Services.GetRequiredService<IOptions<MvcJsonOptions>>();


### PR DESCRIPTION
Some web applications are calling specific extensions methods on IWebHostBuilder that are required to run it, even with the TestHost. It is for example the case with Testavior. So we should be able to run a specific configuration method when invoking our tool.

This method has to be declared on the same type than the web application entry point with this signature:
 `public static IWebHostBuilder ConfigureWebHostBuilder(IWebHostBuilder builder)`

The methods `UseContentRoot` and `UseStartup` are always called by the Swashbuckle tool before invoking the custom configuration method.

Full Program.cs sample:
```csharp
namespace Client.Project.Web
{
    using Microsoft.AspNetCore.Hosting;
    using System.IO;

    public class Program
    {
        public static void Main(string[] args)
        {
            var webHostBuilder = new WebHostBuilder()
                .UseKestrel()
                .UseContentRoot(Directory.GetCurrentDirectory())
                .UseIISIntegration()
                .UseStartup<Startup>();

            ConfigureWebHostBuilder(webHostBuilder);

            var host = webHostBuilder.Build();
            host.Run();
        }

        public static IWebHostBuilder ConfigureWebHostBuilder(IWebHostBuilder builder)
        {
            // Using Testavior
            return builder.ConfigureStartup<StartupConfigurationService>();
        }
    }
}
```
