### PR TITLE
Add editorconfig and fix violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,197 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+# (Please don't specify an indent_size here; that has too many unintended consequences.)
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+# Always use "this." and "Me."
+dotnet_style_qualification_for_field = true:suggestion
+dotnet_style_qualification_for_property = true:suggestion
+dotnet_style_qualification_for_method = true:suggestion
+dotnet_style_qualification_for_event = true:suggestion
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = false:warning
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# Naming Symbols
+# constant_fields - Define constant fields
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+# non_private_readonly_fields - Define public, internal and protected readonly fields
+dotnet_naming_symbols.non_private_readonly_fields.applicable_accessibilities = public, internal, protected
+dotnet_naming_symbols.non_private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_readonly_fields.required_modifiers = readonly
+# static_readonly_fields - Define static and readonly fields
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+# private_readonly_fields - Define private readonly fields
+dotnet_naming_symbols.private_readonly_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.private_readonly_fields.required_modifiers = readonly
+# public_internal_fields - Define public and internal fields
+dotnet_naming_symbols.public_internal_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_internal_fields.applicable_kinds = field
+# private_protected_fields - Define private and protected fields
+dotnet_naming_symbols.private_protected_fields.applicable_accessibilities = private, protected
+dotnet_naming_symbols.private_protected_fields.applicable_kinds = field
+# public_symbols - Define any public symbol
+dotnet_naming_symbols.public_symbols.applicable_accessibilities = public, internal, protected, protected_internal
+dotnet_naming_symbols.public_symbols.applicable_kinds = method, property, event, delegate
+# parameters - Defines any parameter
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+# non_interface_types - Defines class, struct, enum and delegate types
+dotnet_naming_symbols.non_interface_types.applicable_kinds = class, struct, enum, delegate
+# interface_types - Defines interfaces
+dotnet_naming_symbols.interface_types.applicable_kinds = interface
+
+# Naming Styles
+# camel_case - Define the camelCase style
+dotnet_naming_style.camel_case.capitalization = camel_case
+# pascal_case - Define the Pascal_case style
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+# first_upper - The first character must start with an upper-case character
+dotnet_naming_style.first_upper.capitalization = first_word_upper
+# prefix_interface_interface_with_i - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_interface_with_i.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_interface_with_i.required_prefix = I
+
+# Naming Rules
+# Constant fields must be PascalCase
+dotnet_naming_rule.constant_fields_must_be_pascal_case.severity = warning
+dotnet_naming_rule.constant_fields_must_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_must_be_pascal_case.style = pascal_case
+# Public, internal and protected readonly fields must be PascalCase
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.severity = warning
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.symbols = non_private_readonly_fields
+dotnet_naming_rule.non_private_readonly_fields_must_be_pascal_case.style = pascal_case
+# Static readonly fields must be PascalCase
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.severity = warning
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_must_be_pascal_case.style = pascal_case
+# Private readonly fields must be camelCase
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.severity = warning
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.symbols = private_readonly_fields
+dotnet_naming_rule.private_readonly_fields_must_be_camel_case.style = camel_case
+# Public and internal fields must be PascalCase
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.severity = warning
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.symbols = public_internal_fields
+dotnet_naming_rule.public_internal_fields_must_be_pascal_case.style = pascal_case
+# Private and protected fields must be camelCase
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.severity = warning
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.symbols = private_protected_fields
+dotnet_naming_rule.private_protected_fields_must_be_camel_case.style = camel_case
+# Public members must be capitalized
+dotnet_naming_rule.public_members_must_be_capitalized.severity = warning
+dotnet_naming_rule.public_members_must_be_capitalized.symbols = public_symbols
+dotnet_naming_rule.public_members_must_be_capitalized.style = first_upper
+# Parameters must be camelCase
+dotnet_naming_rule.parameters_must_be_camel_case.severity = warning
+dotnet_naming_rule.parameters_must_be_camel_case.symbols = parameters
+dotnet_naming_rule.parameters_must_be_camel_case.style = camel_case
+# Class, struct, enum and delegates must be PascalCase
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.severity = warning
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.symbols = non_interface_types
+dotnet_naming_rule.non_interface_types_must_be_pascal_case.style = pascal_case
+# Interfaces must be PascalCase and start with an 'I'
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.severity = warning
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.symbols = interface_types
+dotnet_naming_rule.interface_types_must_be_prefixed_with_i.style = prefix_interface_interface_with_i
+
+# CSharp code style settings:
+[*.cs]
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Prefer method-like constructs to have a block body
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+
+# Prefer property-like constructs to have an expression-body
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Suggest more modern language features when available
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Modifier preferences
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+
+# Code block preferences
+csharp_prefer_braces = true:suggestion
+
+# Indentation options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+
+# Spacing Options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = none
+
+# Wrapping options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true

--- a/GeekLearning.Swashbuckle.sln
+++ b/GeekLearning.Swashbuckle.sln
@@ -3,8 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26730.15
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A01AC02E-F07B-43B6-AB58-631273BBC278}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "items", "items", "{A01AC02E-F07B-43B6-AB58-631273BBC278}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		GitVersion.yml = GitVersion.yml
@@ -16,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeekLearning.SwashbuckleExt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeekLearning.DotNet.Swashbuckle", "src\GeekLearning.DotNet.Swashbuckle\GeekLearning.DotNet.Swashbuckle.csproj", "{58822602-5E9F-4441-A0A4-77F4562F5890}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeekLearning.Domain.SwahbuckleExtensions", "src\GeekLearning.Domain.SwahbuckleExtensions\GeekLearning.Domain.SwahbuckleExtensions.csproj", "{AB5F6BE6-27DC-4A3A-AA1F-F85F5F4C9569}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeekLearning.Domain.SwahbuckleExtensions", "src\GeekLearning.Domain.SwahbuckleExtensions\GeekLearning.Domain.SwahbuckleExtensions.csproj", "{AB5F6BE6-27DC-4A3A-AA1F-F85F5F4C9569}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/GeekLearning.Domain.SwahbuckleExtensions/MaybeResultDocumentFilter.cs
+++ b/src/GeekLearning.Domain.SwahbuckleExtensions/MaybeResultDocumentFilter.cs
@@ -1,14 +1,13 @@
 ﻿namespace GeekLearning.Domain.SwahbuckleExtensions
 {
-    using Swashbuckle.AspNetCore.SwaggerGen;
-    using Swashbuckle.AspNetCore.Swagger;
+    using System.Threading.Tasks;
     using GeekLearning.Domain.AspnetCore;
     using Microsoft.AspNetCore.Mvc.Controllers;
-    using System.Threading.Tasks;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public class MaybeResultDocumentFilter : IOperationFilter
     {
-
         public void Apply(Operation operation, OperationFilterContext context)
         {
             switch (context.ApiDescription.ActionDescriptor)
@@ -32,7 +31,7 @@
                         {
                             var responseType = typeof(Response<>).MakeGenericType(returnType.GenericTypeArguments[0]);
 
-                            operation.Responses.TryGetValue("200", out Response okResponse);
+                            operation.Responses.TryGetValue("200", out var okResponse);
 
                             if (okResponse == null)
                             {

--- a/src/GeekLearning.DotNet.Swashbuckle/CommandLineOptions.cs
+++ b/src/GeekLearning.DotNet.Swashbuckle/CommandLineOptions.cs
@@ -1,15 +1,15 @@
 ﻿namespace GeekLearning.DotNet.Swashbuckle
 {
+    using System.Collections.Generic;
+    using System.Reflection;
     using Microsoft.DotNet.Cli.Utils;
     using Microsoft.Extensions.CommandLineUtils;
     using NuGet.Frameworks;
-    using System.Collections.Generic;
-    using System.Reflection;
 
     public class CommandLineOptions
     {
-        private static readonly Assembly thisAssembly = typeof(CommandLineOptions).GetTypeInfo().Assembly;
-        private static readonly string assemblyVersion = thisAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? thisAssembly.GetName().Version.ToString();
+        private static readonly Assembly ThisAssembly = typeof(CommandLineOptions).GetTypeInfo().Assembly;
+        private static readonly string AssemblyVersion = ThisAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? ThisAssembly.GetName().Version.ToString();
 
         public string Configuration { get; set; }
 
@@ -78,7 +78,7 @@
                 CommandOptionType.SingleValue
                 );
 
-            app.VersionOption("--version", () => assemblyVersion);
+            app.VersionOption("--version", () => AssemblyVersion);
 
             app.HelpOption("-h|--help");
 

--- a/src/GeekLearning.DotNet.Swashbuckle/Program.cs
+++ b/src/GeekLearning.DotNet.Swashbuckle/Program.cs
@@ -1,22 +1,22 @@
 ﻿namespace GeekLearning.DotNet.Swashbuckle
 {
-    using HandlebarsDotNet;
-    using Microsoft.DotNet.Cli.Utils;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using HandlebarsDotNet;
+    using Microsoft.DotNet.Cli.Utils;
 
     public class Program
     {
-        private const string netCoreAppFramework = "netcoreapp";
-        private const string targetFrameworkProperty = "TargetFramework";
-        private const string targetFrameworksProperty = "TargetFrameworks";
-        private const string intermediateOutputPathProperty = "IntermediateOutputPath";
-        private const string assemblyNameProperty = "AssemblyName";
-        private const string referencesProperty = "References";
+        private const string NetCoreAppFramework = "netcoreapp";
+        private const string TargetFrameworkProperty = "TargetFramework";
+        private const string TargetFrameworksProperty = "TargetFrameworks";
+        private const string IntermediateOutputPathProperty = "IntermediateOutputPath";
+        private const string AssemblyNameProperty = "AssemblyName";
+        private const string ReferencesProperty = "References";
 
         public static void Main(string[] args)
         {
@@ -30,7 +30,7 @@
             var projectDirectory = Path.GetDirectoryName(projectFile);
             var (properties, references) = ReadProperties(projectFile, options.Configuration, options.Framework?.Framework);
 
-            var tempProjectPath = Path.Combine(projectDirectory, properties[intermediateOutputPathProperty], "SwaggerGen");
+            var tempProjectPath = Path.Combine(projectDirectory, properties[IntermediateOutputPathProperty], "SwaggerGen");
             if (!Directory.Exists(tempProjectPath))
             {
                 Directory.CreateDirectory(tempProjectPath);
@@ -41,10 +41,10 @@
             var generationContext = new
             {
                 ProjectPath = projectFile,
-                TargetFramework = properties[targetFrameworkProperty],
-                AssemblyName = properties[assemblyNameProperty],
+                TargetFramework = properties[TargetFrameworkProperty],
+                AssemblyName = properties[AssemblyNameProperty],
                 ContentRoot = projectDirectory,
-                options.ApiVersion,
+                ApiVersion = options.ApiVersion,
                 OutputPath = Path.IsPathRooted(options.OutputPath) ? options.OutputPath : Path.Combine(projectDirectory, options.OutputPath),
                 References = references.ToDictionary(x => x.Key.Replace(".", ""), y => y.Value)
             };
@@ -64,6 +64,7 @@
                                     .Replace(".cst", ".cs"))),
                         template(generationContext));
                 }
+
             }
 
             var restore = Command.CreateDotNet("restore", new string[] { });
@@ -136,10 +137,10 @@
                 $@"<Project>
                       <Target Name=""_GetDotNetNames"" DependsOnTargets=""ResolvePackageDependenciesDesignTime"">
                          <ItemGroup>
-                            <_DotNetNamesOutput Include=""{assemblyNameProperty}: $({assemblyNameProperty})"" />
-                            <_DotNetNamesOutput Include=""{targetFrameworkProperty}: $({targetFrameworkProperty})"" />
-                            <_DotNetNamesOutput Include=""{targetFrameworksProperty}: $({targetFrameworksProperty})"" />
-                            <_DotNetNamesOutput Include=""{intermediateOutputPathProperty}: $({intermediateOutputPathProperty})"" />
+                            <_DotNetNamesOutput Include=""{AssemblyNameProperty}: $({AssemblyNameProperty})"" />
+                            <_DotNetNamesOutput Include=""{TargetFrameworkProperty}: $({TargetFrameworkProperty})"" />
+                            <_DotNetNamesOutput Include=""{TargetFrameworksProperty}: $({TargetFrameworksProperty})"" />
+                            <_DotNetNamesOutput Include=""{IntermediateOutputPathProperty}: $({IntermediateOutputPathProperty})"" />
                          </ItemGroup>
                          <WriteLinesToFile File=""$(_DotNetNamesFile)"" Lines=""@(_DotNetNamesOutput)"" Overwrite=""true"" />
                          <WriteLinesToFile File=""$(_DotNetReferencesFile)"" Lines=""@(_DependenciesDesignTime)"" Overwrite=""true"" />
@@ -149,7 +150,7 @@
             var additionnalParameters = string.Empty;
             if (!string.IsNullOrEmpty(framework))
             {
-                additionnalParameters = $"/p:{targetFrameworkProperty}={framework}";
+                additionnalParameters = $"/p:{TargetFrameworkProperty}={framework}";
             }
 
             var dotNetNamesFileName = Path.GetTempFileName();

--- a/src/GeekLearning.SwashbuckleExtensions/AssignExamples.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/AssignExamples.cs
@@ -2,7 +2,6 @@
 {
     using Swashbuckle.AspNetCore.Swagger;
     using Swashbuckle.AspNetCore.SwaggerGen;
-    using System.Collections.Generic;
 
     public class AssignExamples : IOperationFilter
     {
@@ -15,14 +14,14 @@
 
         public void Apply(Operation operation, OperationFilterContext context)
         {
-            var isSuccessResponse = operation.Responses.TryGetValue("200", out Response successResponse)
+            var isSuccessResponse = operation.Responses.TryGetValue("200", out var successResponse)
                 || operation.Responses.TryGetValue("204", out successResponse);
 
-            if (this.builder.Examples.TryGetValue(context.ApiDescription.ActionDescriptor.DisplayName, out Dictionary<string, Dictionary<string, object>> actionSamples))
+            if (this.builder.Examples.TryGetValue(context.ApiDescription.ActionDescriptor.DisplayName, out var actionSamples))
             {
                 foreach (var statusSamples in actionSamples)
                 {
-                    if (!operation.Responses.TryGetValue(statusSamples.Key, out Response statusResponse))
+                    if (!operation.Responses.TryGetValue(statusSamples.Key, out var statusResponse))
                     {
                         statusResponse = new Response();
                         operation.Responses[statusSamples.Key] = statusResponse;

--- a/src/GeekLearning.SwashbuckleExtensions/AssignSecurityRequirements.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/AssignSecurityRequirements.cs
@@ -1,11 +1,11 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Microsoft.AspNetCore.Authorization;
-    using Swashbuckle.AspNetCore.Swagger;
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Authorization;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public class AssignSecurityRequirements : IOperationFilter
     {

--- a/src/GeekLearning.SwashbuckleExtensions/DropTextPlainConsumes.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/DropTextPlainConsumes.cs
@@ -1,9 +1,9 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Swashbuckle.AspNetCore.Swagger;
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
     using System.Linq;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public class DropTextPlainConsumes : IOperationFilter
     {

--- a/src/GeekLearning.SwashbuckleExtensions/DropTextPlainProduces.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/DropTextPlainProduces.cs
@@ -1,9 +1,9 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Swashbuckle.AspNetCore.Swagger;
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
     using System.Linq;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public class DropTextPlainProduces : IOperationFilter
     {

--- a/src/GeekLearning.SwashbuckleExtensions/ExamplesBuilder.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/ExamplesBuilder.cs
@@ -48,10 +48,10 @@
 
                 var actionId = methodCall.Method.DeclaringType.FullName + "." + methodCall.Method.Name;
 
-                if (!examples.TryGetValue(actionId, out Dictionary<string, Dictionary<string, object>> actionResponses))
+                if (!this.examples.TryGetValue(actionId, out var actionResponses))
                 {
                     actionResponses = new Dictionary<string, Dictionary<string, object>>();
-                    examples[actionId] = actionResponses;
+                    this.examples[actionId] = actionResponses;
                 }
 
                 return new ActionContext<TReturn>(actionResponses);
@@ -70,10 +70,10 @@
 
                 var actionId = methodCall.Method.DeclaringType.FullName + "." + methodCall.Method.Name;
 
-                if (!examples.TryGetValue(actionId, out Dictionary<string, Dictionary<string, object>> actionResponses))
+                if (!this.examples.TryGetValue(actionId, out var actionResponses))
                 {
                     actionResponses = new Dictionary<string, Dictionary<string, object>>();
-                    examples[actionId] = actionResponses;
+                    this.examples[actionId] = actionResponses;
                 }
 
                 return new ActionContext<TReturn>(actionResponses);
@@ -90,10 +90,10 @@
 
                 public ActionContext<TReturn> Json(TReturn data, string status = "200")
                 {
-                    if (!actionResponses.TryGetValue(status, out Dictionary<string, object> statusResponses))
+                    if (!this.actionResponses.TryGetValue(status, out var statusResponses))
                     {
                         statusResponses = new Dictionary<string, object>();
-                        actionResponses[status] = statusResponses;
+                        this.actionResponses[status] = statusResponses;
                     }
 
                     statusResponses.Add("application/json", data);

--- a/src/GeekLearning.SwashbuckleExtensions/FixBasePathDocumentFilter.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/FixBasePathDocumentFilter.cs
@@ -1,11 +1,8 @@
-﻿using Swashbuckle.AspNetCore.SwaggerGen;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Swashbuckle.AspNetCore.Swagger;
-
-namespace GeekLearning.SwashbuckleExtensions
+﻿namespace GeekLearning.SwashbuckleExtensions
 {
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
+
     public class FixBasePathDocumentFilter : IDocumentFilter
     {
         public void Apply(SwaggerDocument swaggerDoc, DocumentFilterContext context)

--- a/src/GeekLearning.SwashbuckleExtensions/GeekLearningExamplesExtensions.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/GeekLearningExamplesExtensions.cs
@@ -1,8 +1,8 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System;
     using System.Collections.Generic;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public static class GeekLearningExamplesExtensions
     {

--- a/src/GeekLearning.SwashbuckleExtensions/SchemesDocumentFilter.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/SchemesDocumentFilter.cs
@@ -1,9 +1,9 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Swashbuckle.AspNetCore.Swagger;
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System.Collections.Generic;
     using System.Linq;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     public class SchemesDocumentFilter : IDocumentFilter
     {

--- a/src/GeekLearning.SwashbuckleExtensions/SwaggerFormOperationFilter.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/SwaggerFormOperationFilter.cs
@@ -1,10 +1,9 @@
 ﻿namespace GeekLearning.SwashbuckleExtensions
 {
-    using Microsoft.AspNetCore.Mvc.ApiExplorer;
-    using Swashbuckle.AspNetCore.Swagger;
-    using Swashbuckle.AspNetCore.SwaggerGen;
     using System.Collections.Generic;
     using System.Linq;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
 
     /// <summary>
     /// Bring support for additional Form parameters without any Model Binder interference. Can be used to tweak swagger UI 
@@ -15,13 +14,14 @@
     {
         public void Apply(Operation operation, OperationFilterContext context)
         {
-
             var requestAttributes = context.ApiDescription.ActionAttributes().Concat(context.ApiDescription.ControllerAttributes()).OfType<SwaggerFormParameterAttribute>();
 
             if (requestAttributes.Any())
             {
                 if (operation.Parameters == null)
+                {
                     operation.Parameters = new List<IParameter>();
+                }
 
                 var parametersToClean = operation.Parameters.OfType<SwaggerFormParameter>().ToArray();
 
@@ -31,7 +31,9 @@
                 }
 
                 if (operation.Consumes.Count == 0)
+                {
                     operation.Consumes.Add("multipart/form-data");
+                }
             }
 
             foreach (var attr in requestAttributes)
@@ -49,10 +51,8 @@
             }
         }
 
-
         private class SwaggerFormParameter : NonBodyParameter
         {
-
         }
     }
 }

--- a/src/GeekLearning.SwashbuckleExtensions/SwaggerFormParameterAttribute.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/SwaggerFormParameterAttribute.cs
@@ -9,14 +9,17 @@
     public sealed class SwaggerFormParameterAttribute : Attribute
     {
         public string Name { get; private set; }
+
         public string Type { get; private set; }
+
         public string Description { get; set; }
+
         public bool IsRequired { get; set; }
 
         public SwaggerFormParameterAttribute(string name, string type)
         {
-            Name = name;
-            Type = type;
+            this.Name = name;
+            this.Type = type;
         }
     }
 }

--- a/src/GeekLearning.SwashbuckleExtensions/XNullableFilter.cs
+++ b/src/GeekLearning.SwashbuckleExtensions/XNullableFilter.cs
@@ -1,11 +1,9 @@
-﻿using Swashbuckle.AspNetCore.SwaggerGen;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Swashbuckle.AspNetCore.Swagger;
-
-namespace GeekLearning.SwashbuckleExtensions
+﻿namespace GeekLearning.SwashbuckleExtensions
 {
+    using System;
+    using Swashbuckle.AspNetCore.Swagger;
+    using Swashbuckle.AspNetCore.SwaggerGen;
+
     public class XNullableFilter : ISchemaFilter
     {
         private readonly bool omitFalseValue;
@@ -21,7 +19,7 @@ namespace GeekLearning.SwashbuckleExtensions
 
         public void Apply(Schema model, SchemaFilterContext context)
         {
-            bool nullable = !context.SystemType.IsValueType;
+            var nullable = !context.SystemType.IsValueType;
 
             var type = context.SystemType;
             if (type.IsConstructedGenericType)
@@ -33,8 +31,8 @@ namespace GeekLearning.SwashbuckleExtensions
                     //var nullableUnderlyingType = Nullable.GetUnderlyingType(context.SystemType);
                 }
             }
-           
-            if (nullable || !omitFalseValue)
+
+            if (nullable || !this.omitFalseValue)
             {
                 model.Extensions["x-nullable"] = nullable;
             }


### PR DESCRIPTION
The editorconfig file specifies the coding style that we are used to, and the official [Naming Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/naming-guidelines) from Microsoft.

It should be added on all our projects, but I'm not sure how to handle the changes... Maybe we should open a specific repo for our common files (.editorconfig, .gitignore, GitVersion.yml, Nuget.config, etc...)?

Would be happy to read your thoughts 😃 